### PR TITLE
동시성이슈 로직 및 테스트

### DIFF
--- a/src/main/kotlin/dev/lecture_clean_tdd/adapter/persistence/LectureRepositoryImpl.kt
+++ b/src/main/kotlin/dev/lecture_clean_tdd/adapter/persistence/LectureRepositoryImpl.kt
@@ -19,10 +19,10 @@ class LectureRepositoryImpl(
     override fun findById(lectureId: Long): Lecture? {
         return jpaLectureRepository.findByIdOrNull(lectureId)
     }
-
-    override fun findByIdWithLock(lectureId: Long): Lecture? {
-        return jpaLectureRepository.findByIdWithLock(lectureId)
-    }
+ 
+    override fun findByIdWithLock(lectureId: Long): Lecture? { 
+        return jpaLectureRepository.findByIdWithLock(lectureId) 
+    } 
 
     override fun findAll(): List<Lecture> {
         return jpaLectureRepository.findAll()

--- a/src/main/kotlin/dev/lecture_clean_tdd/adapter/persistence/jpa/JpaLectureRepository.kt
+++ b/src/main/kotlin/dev/lecture_clean_tdd/adapter/persistence/jpa/JpaLectureRepository.kt
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface JpaLectureRepository : JpaRepository<Lecture, Long>  {
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select l from Lecture l where l.id = :lectureId")
-    fun findByIdWithLock(lectureId: Long) : Lecture
-}
+interface JpaLectureRepository : JpaRepository<Lecture, Long>  { 
+ 
+    @Lock(LockModeType.PESSIMISTIC_WRITE) 
+    @Query("select l from Lecture l where l.id = :lectureId") 
+    fun findByIdWithLock(lectureId: Long) : Lecture 
+} 

--- a/src/main/kotlin/dev/lecture_clean_tdd/application/port/output/LectureRepository.kt
+++ b/src/main/kotlin/dev/lecture_clean_tdd/application/port/output/LectureRepository.kt
@@ -5,6 +5,6 @@ import dev.lecture_clean_tdd.domain.entity.Lecture
 interface LectureRepository {
     fun save(lecture : Lecture) : Long
     fun findById(lectureId : Long) : Lecture?
-    fun findByIdWithLock(lectureId: Long): Lecture?
+    fun findByIdWithLock(lectureId: Long): Lecture? 
     fun findAll(): List<Lecture>
 }

--- a/src/main/kotlin/dev/lecture_clean_tdd/application/service/RegisterLectureService.kt
+++ b/src/main/kotlin/dev/lecture_clean_tdd/application/service/RegisterLectureService.kt
@@ -47,9 +47,9 @@ class RegisterLectureService(
         return userRepository.findById(userId) ?: throw UserNotFoundException("유저를 찾을 수 없습니다")
     }
 
-    private fun getLecture(lectureId: Long): Lecture {
-        return lectureRepository.findByIdWithLock(lectureId) ?: throw LectureNotFoundException("강의를 찾을 수 없습니다")
-    }
+    private fun getLecture(lectureId: Long): Lecture { 
+        return lectureRepository.findByIdWithLock(lectureId) ?: throw LectureNotFoundException("강의를 찾을 수 없습니다") 
+    } 
 
     private fun ensureUniqueRegistration(user: User, lecture: Lecture) {
         lectureAttendeeRepository.findByUserAndLecture(user, lecture)?.let {


### PR DESCRIPTION
## 동시성 이슈

비관적락을 사용해서 동시성 이슈를 해결했습니다.
특강신청 인원이 30명인 만큼 특강신청에서 순서가 중요하다고 느꼈고
비관적락의 경우 순서보장을 해주고, 충돌이 빈번한 상황에서 낙관적락보다 효율적이기에 선택했습니다.